### PR TITLE
Fixed Drawer does not auto-expand parents of active item

### DIFF
--- a/packages/component-library/src/core/Drawer/DrawerNavItem.tsx
+++ b/packages/component-library/src/core/Drawer/DrawerNavItem.tsx
@@ -244,12 +244,11 @@ export const DrawerNavItem: React.FC<DrawerNavItemProps> = (props) => {
         depth > 0 ? (nestedDivider !== undefined ? nestedDivider : false) : divider !== undefined ? divider : false;
 
     // When the activeItem changes, update our expanded state
-    // Temporarily disabling this auto-expand behavior due to a bug in the react-native-collapsible with calculating the correct starting height
-    // useEffect(() => {
-    //     if (isInActiveTree && !expanded) {
-    //         setExpanded(true);
-    //     }
-    // }, [isInActiveTree]); // Only update if the active tree changes (not after manual expand/collapse action)
+    useEffect(() => {
+        if (isInActiveTree && !expanded) {
+            setExpanded(true);
+        }
+    }, [isInActiveTree]); // Only update if the active tree changes (not after manual expand/collapse action)
 
     // If the active item changes
     useEffect(() => {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #175 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Reverted back auto-expand
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
<img width="440" alt="new" src="https://github.com/user-attachments/assets/dc4f916f-ee37-4712-a2b2-3436411faf4b" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
