### PR TITLE
Inconsistent Styling Between Email and Password Fields on Login Page with RN 0.80 + Version

### DIFF
--- a/packages/auth-workflows/src/screens/LoginScreen/LoginScreenBase.tsx
+++ b/packages/auth-workflows/src/screens/LoginScreen/LoginScreenBase.tsx
@@ -262,6 +262,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
                             <PasswordTextField
                                 testID={'blui-login-password-text-field'}
                                 ref={passwordField}
+                                {...passwordTextFieldProps}
                                 onChangeText={(e: any): void => {
                                     passwordTextFieldProps?.onChange?.(e);
                                     handlePasswordInputChange(e);


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-6999 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fix for the [issue](https://github.com/etn-ccis/blui-react-native/issues/355)
- Spread the Password Text Props to password text field

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="353" height="653" alt="Screenshot 2025-09-24 at 6 06 14 PM" src="https://github.com/user-attachments/assets/6e3abbb1-3c0f-4411-9d50-b92afd40b8b4" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [ ] Code passes all linting checks
- [ ] All tests pass
- [ ] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] Changelog has been updated (if applicable)
